### PR TITLE
Proofread Docs

### DIFF
--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ main_board = power_boards['POWER']
 main_board = power_boards[0]
 ```
 
-This power board object has two functions, power_on() and power_off() these turn the power on and off to the connected boards respectively.
+This power board object has two functions, `power_on()` and `power_off()` these turn the power on and off to the connected boards respectively.
 
 ```python
 # powers on the connected boards
@@ -64,7 +64,7 @@ It is a good idea to assign the left and right motor object to memorable variabl
 left_motor = robot.motor_boards['mOtOr'].m0
 right_motor = robot.motor_boards['mOtOr'].m1
 ```
-These Motor objects have a property called voltage, which can be read and set like any other variable.
+These Motor objects have a property called `voltage`, which can be read and set like any other variable.
 
 Note that this number has been normalised to be between -1 and 1 and is not the actual voltage being applied to the motor.
 
@@ -85,8 +85,8 @@ right_motor.voltage
 
 The motor board would then apply full power to both motors.
 
-In addition to the numeric values, there are two text constants that can be used. robot.BRAKE and robot.COAST.
-robot.BRAKE is an alias for 0 (full stop), while robot.COAST stops the application of power to the motors.
+In addition to the numeric values, there are two text constants that can be used. `robot.BRAKE` and `robot.COAST`.
+`robot.BRAKE` is an alias for 0 (full stop), while `robot.COAST` stops the application of power to the motors.
 
 ## Ruggeduino (Servo Boards)
 
@@ -120,7 +120,7 @@ cameras = robot.cameras
 camera_one = cameras['camera']
 ```
 
-Once you have a camera object you can check what markers it can see by using its see() command, this will return a list of marker objects.
+Once you have a camera object you can check what markers it can see by using its `see()` command, this will return a list of marker objects.
 ```python
 markers = camera_one.see()
 ```

--- a/index.md
+++ b/index.md
@@ -1,8 +1,8 @@
-# Robot API Tutorial 
+# Robot API Tutorial
 
 This is the documentation tutorial showing how to use the robot's API.
 
-[See the api reference.](reference)
+[See the API reference.](reference)
 ## Setup
 
 The following two lines of python code are required to setup the robot.
@@ -13,7 +13,7 @@ from robot import Robot
 robot = Robot()
 ```
 
-This will initialize the robot's api calls and allow it to send and receive data from the robot's various boards.
+This will initialize the robot's API calls and allow it to send and receive data from the robot's various boards.
 
 Once this has been setup, this object can be used for most of the functions of the robot.
 
@@ -133,4 +133,3 @@ eg_marker.id in robot.TOKEN
 eg_maker.id in robot.SILVER_TOKEN
 # true
 ```
-

--- a/index.md
+++ b/index.md
@@ -22,20 +22,24 @@ Once this has been setup, this object can be used for most of the functions of t
 As with the motor boards, the serial number of the power board is needed. Once you have this you can obtain access to a power board as follows:
 
 ```python
+# get a dictionairy of the connected power boards
 power_boards = robot.power_boards
-# gets a dictionairy of the connected power boards
+
+# get the power board by serial number
 main_board = power_boards['POWER']
-# get the power board with that serial number
+
+# get the first power board
+main_board = power_boards[0]
 ```
 
 This power board object has two functions, power_on() and power_off() these turn the power on and off to the connected boards respectivley.
 
 ```python
-main_board.power_on()
 # powers on the connected boards
+main_board.power_on()
 
-main_board.power_off()
 # powers off the connected boards
+main_board.power_off()
 ```
 
 ## Motor Boards
@@ -45,10 +49,11 @@ Once this is done, the motors and their boards are accessed
 as follows:
 
 ```python
-motor_boards = robot.motor_boards
 # a dictionairy of the avaliable motor boards
+motor_boards = robot.motor_boards
+
+# Selects the motor board by serial number
 board_one = motor_boards['mOtOr']
-# Selects the board with that serial number
 ```
 
 This board object has a property object for each of the motors connected to it. These are mapped to the m1 and m0 variables.
@@ -72,10 +77,10 @@ right_motor.voltage = 1
 and these value can then be read like that:
 ```python
 left_motor.voltage
-# 1
+# >>> 1
 
 right_motor.voltage
-# 1
+# >>> 1
 ```
 
 The motor board would then apply full power to both motors.
@@ -88,16 +93,14 @@ robot.BRAKE is an alias for 0 (full stop), while robot.COAST stops the applicati
 get a dictionairy of connected servo boards with the serial numbers as keys:
 
 ```python
-servo_boards = robot.servo_boards
-# get a dictionairy of the servo boards
-board_one = servo_boards['S3rv0']
 # get a single board by serial number
+board_one = servo_boards['S3rv0']
 ```
 Once you have a single servo board you can get the list of servos connected to that board and read and set the position of that servo:
 
 ```python
-servo_one = board_one.ports[1]
 # get the second element of the list of ports
+servo_one = board_one.ports[1]
 ```
 
 The position of the selected servo can then be set and read as followings:
@@ -106,7 +109,7 @@ The position of the selected servo can then be set and read as followings:
 servo_one.position = 65
 
 position = servo_one.position
-# 65
+# >>> 65
 ```
 
 ## Cameras (Vision Boards)
@@ -125,11 +128,11 @@ Once you've got a marker object, you can check its id number against the predefi
 ```python
 eg_marker = markers[0]
 eg_marker.id
-# 34
+# >>> 34
 eg_marker.id in robot.WALL
-# false
+# >>> false
 eg_marker.id in robot.TOKEN
-# true
+# >>> true
 eg_maker.id in robot.SILVER_TOKEN
-# true
+# >>> true
 ```

--- a/index.md
+++ b/index.md
@@ -1,11 +1,10 @@
 # Robot API Tutorial
-
 This is the documentation tutorial showing how to use the robot's API.
 
 [See the API reference.](reference)
-## Setup
 
-The following two lines of python code are required to setup the robot.
+## Setup
+The following two lines are required to setup the robot.
 
 ```python
 from robot import Robot
@@ -18,9 +17,6 @@ This will initialize the robot's API calls and allow it to send and receive data
 Once this has been setup, this object can be used for most of the functions of the robot.
 
 ## Power Boards
-
-As with the motor boards, the serial number of the power board is needed. Once you have this you can obtain access to a power board as follows:
-
 ```python
 # get a dictionary of the connected power boards
 power_boards = robot.power_boards
@@ -34,20 +30,12 @@ main_board = power_boards[0]
 
 This power board object has two functions, `power_on()` and `power_off()` these turn the power on and off to the connected boards respectively.
 
-```python
-# powers on the connected boards
-main_board.power_on()
-
-# powers off the connected boards
-main_board.power_off()
-```
+`power_on()` is called during initialization, so this isn't needed.
 
 ## Motor Boards
-in order to use a motor board, you will first have to read the serial number off the motor boards:
+In order to use a motor board, you will first have to read the serial number off the motor boards:
 
-Once this is done, the motors and their boards are accessed
-as follows:
-
+Once this is done, the motors and their boards are accessed as follows:
 ```python
 # a dictionary of the available motor boards
 motor_boards = robot.motor_boards
@@ -56,24 +44,24 @@ motor_boards = robot.motor_boards
 board_one = motor_boards['mOtOr']
 ```
 
-This board object has a property object for each of the motors connected to it. These are mapped to the m1 and m0 variables.
+This board object has a property object for each of the motors connected to it. These are mapped to the `m1` and `m0` variables.
 
 It is a good idea to assign the left and right motor object to memorable variables, similar to the following
-
 ```python
 left_motor = robot.motor_boards['mOtOr'].m0
 right_motor = robot.motor_boards['mOtOr'].m1
 ```
-These Motor objects have a property called `voltage`, which can be read and set like any other variable.
 
-Note that this number has been normalised to be between -1 and 1 and is not the actual voltage being applied to the motor.
+These `Motor` objects have a property called `voltage`, which is used to set the power of the motors, between -1 and 1.
+
+Note that this number is not the actual voltage being applied to the motor.
 
 So setting the voltage of the motors works like this:
-
 ```python
 left_motor.voltage  = 1
 right_motor.voltage = 1
 ```
+
 and these value can then be read like that:
 ```python
 left_motor.voltage
@@ -91,13 +79,12 @@ In addition to the numeric values, there are two text constants that can be used
 ## Ruggeduino (Servo Boards)
 
 get a dictionary of connected servo boards with the serial numbers as keys:
-
 ```python
 # get a single board by serial number
 board_one = servo_boards['S3rv0']
 ```
-Once you have a single servo board you can get the list of servos connected to that board and read and set the position of that servo:
 
+Once you have a single servo board you can get the list of servos connected to that board and read and set the position of that servo:
 ```python
 # get the second element of the list of ports
 servo_one = board_one.ports[1]
@@ -105,16 +92,15 @@ servo_one = board_one.ports[1]
 
 The position of the selected servo can then be set and read as followings:
 ```python
-
 servo_one.position = 65
 
 position = servo_one.position
-# >>> 65
+# 65
 ```
 
 ## Cameras (Vision Boards)
-
 As always, a dictionary of the available cameras is obtained, then an individual camera is obtained using the serial number, as follows:
+
 ```python
 cameras = robot.cameras
 camera_one = cameras['camera']
@@ -124,6 +110,7 @@ Once you have a camera object you can check what markers it can see by using its
 ```python
 markers = camera_one.see()
 ```
+
 Once you've got a marker object, you can check its id number against the predefined lists to see what type of marker it is:
 ```python
 eg_marker = markers[0]

--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ Once this has been setup, this object can be used for most of the functions of t
 As with the motor boards, the serial number of the power board is needed. Once you have this you can obtain access to a power board as follows:
 
 ```python
-# get a dictionairy of the connected power boards
+# get a dictionary of the connected power boards
 power_boards = robot.power_boards
 
 # get the power board by serial number
@@ -32,7 +32,7 @@ main_board = power_boards['POWER']
 main_board = power_boards[0]
 ```
 
-This power board object has two functions, power_on() and power_off() these turn the power on and off to the connected boards respectivley.
+This power board object has two functions, power_on() and power_off() these turn the power on and off to the connected boards respectively.
 
 ```python
 # powers on the connected boards
@@ -49,7 +49,7 @@ Once this is done, the motors and their boards are accessed
 as follows:
 
 ```python
-# a dictionairy of the avaliable motor boards
+# a dictionary of the available motor boards
 motor_boards = robot.motor_boards
 
 # Selects the motor board by serial number
@@ -90,7 +90,7 @@ robot.BRAKE is an alias for 0 (full stop), while robot.COAST stops the applicati
 
 ## Ruggeduino (Servo Boards)
 
-get a dictionairy of connected servo boards with the serial numbers as keys:
+get a dictionary of connected servo boards with the serial numbers as keys:
 
 ```python
 # get a single board by serial number
@@ -114,7 +114,7 @@ position = servo_one.position
 
 ## Cameras (Vision Boards)
 
-As always, a dictionairy of the avaliable cameras is obtained, then an inidivual camera is obtained using the serial number, as follows:
+As always, a dictionary of the available cameras is obtained, then an individual camera is obtained using the serial number, as follows:
 ```python
 cameras = robot.cameras
 camera_one = cameras['camera']

--- a/reference.md
+++ b/reference.md
@@ -4,112 +4,112 @@
 
 Class that represents a camera
 - **Methods**
-  - see( ): returns a list of [markers](#robotmarker) currently visible to the camera.
+  - `see()`: returns a list of [markers](#robotmarker) currently visible to the camera.
 
 
 - **Properties**
-  - serial: the camera's serial number.
+  - `serial`: the camera's serial number.
 
 ---
 
 ### robot.CartCoord
 Class that represents a set of cartesian coordinates
 - **Properties**
-  - x: x-axis cartesian coordinate in meters.
-  - y: y-axis cartesian coordinate in meters.
-  - z: z-axis cartesian coordinate in meters.
+  - `x`: x-axis cartesian coordinate in meters.
+  - `y`: y-axis cartesian coordinate in meters.
+  - `z`: z-axis cartesian coordinate in meters.
 
 ---
 
 ### robot.Marker
 Class that represents a marker
 - **Methods**
-  - is_token_marker( ): returns true if the marker is a token, false if otherwise.
-  - is_wall_marker( ): returns true if the marker is a wall, false if otherwise.
+  - `is_token_marker()`: returns true if the marker is a token, false if otherwise.
+  - `is_wall_marker()`: returns true if the marker is a wall, false if otherwise.
 
 
 - **Properties**
-  - cartesian: a [CartCoord](#robotcartcoord) object representing the cartesian coordinates of the marker relative to the robot.
-  - distance_meters: the distance to the marker in meters.
-  - id: the id number of the marker.
-  - pixel_centre: pixel coordinates of the centre of the marker.
-  - pixel_corners: pixel coordinates of the corners of the maker.
-  - polar: a [PolarCoord](#robotpolarcoord) object representing the polar coordinates of the marker relative to the robot.
-  - size: size of the marker in meters.
+  - `cartesian`: a [CartCoord](#robotcartcoord) object representing the cartesian coordinates of the marker relative to the robot.
+  - `distance_meters`: the distance to the marker in meters.
+  - `id`: the id number of the marker.
+  - `pixel_centre`: pixel coordinates of the centre of the marker.
+  - `pixel_corners`: pixel coordinates of the corners of the maker.
+  - `polar`: a [PolarCoord](#robotpolarcoord) object representing the polar coordinates of the marker relative to the robot.
+  - `size`: size of the marker in meters.
 
 ---
 
 ### robot.Motor
 Class that represents a motor
 - **Properties**
-  - voltage : the normalised voltage of the motor.
+  - `voltage` : the normalised voltage of the motor.
 
 ---
 
 ### robot.MotorBoard
 Class that represents a motor board
 - **Properties**
-  - m0: The [motor](#robotmotor) connected to m0 on the motor board.
-  - m1: The [motor](#robotmotor) connected to m1 on the motor board
-  - serial: the board's serial number.
+  - `m0`: The [motor](#robotmotor) connected to m0 on the motor board.
+  - `m1`: The [motor](#robotmotor) connected to m1 on the motor board
+  - `serial`: the board's serial number.
 
 ---
 
 ###  robot.PolarCoord
 Class that represents a set of polar coordinates
 - **Properties**
-  - distance_meters: distance to the point in meters.
-  - rot\_x_deg: rotation on the x axis in degrees.
-  - rot\_y_deg: rotation on the y axis in degrees.
-  - rot\_z_deg: rotation on the z axis in degrees.
-  - rot\_x_rad: rotation on the x axis in radians.
-  - rot\_y_rad: rotation on the y axis in radians.
-  - rot\_z_rad: rotation on the z axis in radians.
+  - `distance_meters`: distance to the point in meters.
+  - `rot\_x_deg`: rotation on the x axis in degrees.
+  - `rot\_y_deg`: rotation on the y axis in degrees.
+  - `rot\_z_deg`: rotation on the z axis in degrees.
+  - `rot\_x_rad`: rotation on the x axis in radians.
+  - `rot\_y_rad`: rotation on the y axis in radians.
+  - `rot\_z_rad`: rotation on the z axis in radians.
 
 ---
 
 ###  robot.PowerBoard
 Class that represents a power board
 - **Methods**
-  - power_on( ): turns the power on to the connected boards.
-  - power_off( ): turns the power off to connected boards.
+  - `power_on()`: turns the power on to the connected boards.
+  - `power_off()`: turns the power off to connected boards.
 
 
 - **Properties**
-  - serial: the board's serial number.
+  - `serial`: the board's serial number.
 
 ---
 
 ###  robot.Robot
 Class that represents the robot as a whole
 - **Properties**
-  - cameras: a dictionairy of connected [Cameras](#robotcamera), using their serial numbers as keys.
-  - motor_boards: a dictionairy of connected [Motor Boards](#robotmotorboard), using their serial numbers as keys.
-  - power_boards: a dictionairy of connected [Power Boards](#robotpowerboard), using their serial numbers as keys.
-  - servo_boards: a dictionairy of connected [Servo Board](#robotservoboard), using their serial numbers as keys.
+  - `cameras`: a dictionairy of connected [Cameras](#robotcamera), using their serial numbers as keys.
+  - `motor_boards`: a dictionairy of connected [Motor Boards](#robotmotorboard), using their serial numbers as keys.
+  - `power_boards`: a dictionairy of connected [Power Boards](#robotpowerboard), using their serial numbers as keys.
+  - `servo_boards`: a dictionairy of connected [Servo Board](#robotservoboard), using their serial numbers as keys.
 
 ---
 
 ###  robot.Servo
 Class that represents a servo
 - **Properties**
-  - position: the position of the servo.
+  - `position`: the position of the servo.
 
 ---
 
 ###  robot.ServoBoard
 Class representing a servo board
 - **Properties**
-  - ports: returns a list of up to sixteen [servos](#robotservo), indexed by port number.
-  - serial: Serial number for the board.
+  - `ports`: returns a list of up to sixteen [servos](#robotservo), indexed by port number.
+  - `serial`: Serial number for the board.
 
 ---
 ### Data Values
 Constant data values found inside the robot library.
-- BRAKE: used by [motors](#robotmotor) to tell it to break
-- COAST: used by [motors](#robotmotor) to tell it to coast
-- GOLD_TOKEN: a list of the id numbers of all gold token markers
-- POISON_TOKEN: a list of the id numbers of all poison token markers
-- SILVER_TOKEN: a list of the id numbers of all silver token markers
-- TOKEN: a list of the id numbers of all token markers
-- WALL: a list of the id numbers of all wall markers.
+- `BRAKE`: used by [motors](#robotmotor) to tell it to break
+- `COAST`: used by [motors](#robotmotor) to tell it to coast
+- `GOLD_TOKEN`: a list of the id numbers of all gold token markers
+- `POISON_TOKEN`: a list of the id numbers of all poison token markers
+- `SILVER_TOKEN`: a list of the id numbers of all silver token markers
+- `TOKEN`: a list of the id numbers of all token markers
+- `WALL`: a list of the id numbers of all wall markers.

--- a/reference.md
+++ b/reference.md
@@ -44,7 +44,7 @@ Class that represents a motor
 - **Properties**
   - voltage : the normalised voltage of the motor.
 
----   
+---
 
 ### robot.MotorBoard
 Class that represents a motor board

--- a/reference.md
+++ b/reference.md
@@ -1,5 +1,7 @@
 # Robot API Reference
+
 [Usage Tutorial](index)
+
 ### robot.Camera
 
 Class that represents a camera
@@ -11,7 +13,6 @@ Class that represents a camera
   - `serial`: the camera's serial number.
 
 ---
-
 ### robot.CartCoord
 Class that represents a set of cartesian coordinates
 - **Properties**
@@ -20,12 +21,11 @@ Class that represents a set of cartesian coordinates
   - `z`: z-axis cartesian coordinate in meters.
 
 ---
-
 ### robot.Marker
 Class that represents a marker
 - **Methods**
-  - `is_token_marker()`: returns true if the marker is a token, false if otherwise.
-  - `is_wall_marker()`: returns true if the marker is a wall, false if otherwise.
+  - `is_token_marker()`: if the marker is a token marker.
+  - `is_wall_marker()`: if the marker is a wall marker.
 
 
 - **Properties**
@@ -38,14 +38,12 @@ Class that represents a marker
   - `size`: size of the marker in meters.
 
 ---
-
 ### robot.Motor
 Class that represents a motor
 - **Properties**
   - `voltage` : the normalised voltage of the motor.
 
 ---
-
 ### robot.MotorBoard
 Class that represents a motor board
 - **Properties**
@@ -54,7 +52,6 @@ Class that represents a motor board
   - `serial`: the board's serial number.
 
 ---
-
 ###  robot.PolarCoord
 Class that represents a set of polar coordinates
 - **Properties**
@@ -67,7 +64,6 @@ Class that represents a set of polar coordinates
   - `rot\_z_rad`: rotation on the z axis in radians.
 
 ---
-
 ###  robot.PowerBoard
 Class that represents a power board
 - **Methods**
@@ -79,7 +75,6 @@ Class that represents a power board
   - `serial`: the board's serial number.
 
 ---
-
 ###  robot.Robot
 Class that represents the robot as a whole
 - **Properties**
@@ -89,14 +84,12 @@ Class that represents the robot as a whole
   - `servo_boards`: a dictionairy of connected [Servo Board](#robotservoboard), using their serial numbers as keys.
 
 ---
-
 ###  robot.Servo
 Class that represents a servo
 - **Properties**
   - `position`: the position of the servo.
 
 ---
-
 ###  robot.ServoBoard
 Class representing a servo board
 - **Properties**


### PR DESCRIPTION
- _API_ should be upper case
- Cleanup code examples
- Correct Spelling
- Highlight variables
- General Cleanup