### PR TITLE
Add license file respecting history from imported content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2010-2017 Chris Kirkham <chrisjameskirkham@gmail.com>
+	      		Richard Barlow <richard@richardbarlow.co.uk>
+			Andrew Busse <andybusse@studentrobotics.org>
+			Robert Spanton <rspanton@zepler.net>
+			Peter Law <PeterJCLaw@gmail.com>
+			Alastair Lynn <arplynn@gmail.com>
+			Alex Forward <aforward@studentrobotics.org>
+			Jeremy Morse <jmorse+git@studentrobotics.org>
+			Sam Phippen <samphippen@googlemail.com>
+			Stephen English <steve@secomputing.co.uk>
+			Jake Howard <jhoward@sourcebots.co.uk>
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.


### PR DESCRIPTION
This is MIT with additional contributors, due to importing kit and
board docs and whirlwind tour from https://github.com/srobo/docs.