### PR TITLE
Remove simulator page

### DIFF
--- a/content/simulator/_index.md
+++ b/content/simulator/_index.md
@@ -1,3 +1,0 @@
----
-title: Simulator
----


### PR DESCRIPTION
Due to time restraints, we're not shipping a simulator instantly, so we can remove this placeholder page.

If we decide we do want to ship it later, the page can be restored.