### PR TITLE
Add a Nix environment definition

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+# Require hugo >= 0.30.
+assert (builtins.compareVersions hugo.version "0.30") >= 0;
+
+stdenv.mkDerivation {
+  name = "docs-env";
+  buildInputs = [
+    hugo
+    nodejs
+  ];
+}


### PR DESCRIPTION
This allows users running the Nix package manager to instantly get
an environment containing `hugo` and `npm` by running `nix-shell shell.nix`.

Includes a version check for `hugo >= 0.30`. This is important because
the current stable release of the Nix package set (17.09) ships version 0.29,
which doesn't meet our minimum requirements. Unfortunately I haven't
managed to get this to print anything nicer than "assertion failed"
when the version check fails.