### PR TITLE
Specify npm is only for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ URL: http://docs.sourcebots.co.uk
 
 ## Requirements
 - [Hugo](https://gohugo.io) (>=0.30)
-- [NodeJS](https://nodejs.org/) (>=6)
+- [NodeJS](https://nodejs.org/) (>=6) (required for tests only)
 
 ## Local Setup
 1. `npm install`

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ The site will be output to `public/`.
 ## Dev server
 `./scripts/server.sh` will start a server on http://localhost:1313.
 
+## Tests
+Running tests locally is optional, as theyre automatically run by the CI in PRs. 
+
+Currently, the only test run is a spell-checker.


### PR DESCRIPTION
`npm` is only needed for tests (specifically spell checker), so it's not necessary to have to build the site.

@kierdavis not sure if `nix` supports some kind of _test dependency_ entry?

