### PR TITLE
shell.nix: make test-only dependencies optional

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {}, withTestSupport ? true }:
 
 with pkgs;
 
@@ -9,6 +9,5 @@ stdenv.mkDerivation {
   name = "docs-env";
   buildInputs = [
     hugo
-    nodejs
-  ];
+  ] ++ lib.optional withTestSupport nodejs;
 }


### PR DESCRIPTION
nodejs is only required to run the test suite.

Follows on from #81.