### PR TITLE
Change baseurl to https

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-baseURL: http://docs.sourcebots.co.uk
+baseURL: https://docs.sourcebots.co.uk
 languageCode: en-gb
 title: SourceBots Documentation
 theme: learn


### PR DESCRIPTION
Now that docs have moved to netlify (#83), we can swap the base url to be `https` 🎉 