### PR TITLE
Vision cleanup no polar

### DIFF
--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -19,6 +19,7 @@ The markers in the list have some useful attributes:
 - `id` - returns the [id](marker-ids) of the marker.
 - `pixel_centre` - returns the location in pixels of the centre of the marker in the captured image.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.
+- `polar` - *Deprecated*. Returns coordinate data in an undocumend manner.
 
 ## Marker PDFs
 You can download PDF files of all markers:

--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -19,7 +19,7 @@ The markers in the list have some useful attributes:
 - `id` - returns the [id](marker-ids) of the marker.
 - `pixel_centre` - returns the location in pixels of the centre of the marker in the captured image.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.
-- `polar` - *Deprecated*. Returns coordinate data in an undocumend manner.
+- `polar` - *Deprecated*. Returns coordinate data in an undocumented manner.
 
 ## Marker PDFs
 You can download PDF files of all markers:

--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -18,12 +18,7 @@ The markers in the list have some useful attributes:
 - `is_token_marker()` - returns whether or not the marker is a [token marker](marker-ids/#token-markers).
 - `id` - returns the [id](marker-ids) of the marker.
 - `pixel_centre` - returns the location in pixels of the centre of the marker in the captured image.
-- `polar` - returns details of the position of the marker in the [polar](coordinates/#polar-coordinates) coordinate system.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.
-
-{{% notice tip %}}
-A marker's position can be represented using both the [polar](coordinates/#polar-coordinates) and [Cartesian](coordinates/#cartesian-coordinates) coordinate systems.
-{{% /notice %}}
 
 ## Marker PDFs
 You can download PDF files of all markers:

--- a/content/api/vision/coordinates.md
+++ b/content/api/vision/coordinates.md
@@ -2,23 +2,11 @@
 title: Coordinates
 ---
 
-[Polar coordinates](https://en.wikipedia.org/wiki/Polar_coordinate_system) represent a distance from a set point and an angle from a set direction. [Cartesian coordinates](https://en.wikipedia.org/wiki/Cartesian_coordinate_system) use three perpendicular axes (typically _x_, _y_ and _z_) to specify a point in space.
+[Cartesian coordinates](https://en.wikipedia.org/wiki/Cartesian_coordinate_system) use three perpendicular axes (typically _x_, _y_ and _z_) to specify a point in space.
 
 {{% notice note %}}
 All distances are measured in metres.
 {{% /notice %}}
-
-## Polar Coordinates
-The polar coordinates of a marker are relative to the view of the camera.
-
- - `distance_metres` - the distance from the camera to the marker.
- - `rot_x_rad` / `rot_x_deg` - the angle of rotation in radians/degrees about the x axis. The x axis runs horizontally in front of the camera. A positive angle would be one where the marker is in front of the camera.
- - `rot_y_rad` / `rot_y_deg` - the angle of rotation in radians/degrees about the y axis. The y axis runs vertically in front of the camera. A positive angle would be one where the marker is rotated clockwise about the y axis looking from the top of the marker.
- 
-{{% notice info %}}
-For example, if `distance_metres` was `1`, `rot_x_deg` was `0`, and `rot_y_deg` was `45`, the marker would be 45 degrees to the right of the robot, exactly 1 metre away.
-{{% /notice %}}
-
 
 ## Cartesian Coordinates
 The Cartesian position is represented as 3 coordinates, `x`, `y` and `z`. These coordinates are relative to the view of the webcam.
@@ -28,7 +16,3 @@ The Cartesian position is represented as 3 coordinates, `x`, `y` and `z`. These 
 - `z` - the z coordinate, the distance forwards in front of the camera.
 
 For example, if `x`, `y` and `z` were `0`, `0` and `1` respectively, the marker would be one metre directly in front of the camera.
-
-{{% notice warning %}}
-`z` is not the same as the [polar](#polar-coordinates) `distance_metres`. For example, if `x`, `y` and `z` were `1`, `0` and `1` respectively, the marker would be one metre in front, and one metre to the right of the camera, and so would be `1.412` metres from the camera.
-{{% /notice %}}

--- a/content/api/vision/coordinates.md
+++ b/content/api/vision/coordinates.md
@@ -21,7 +21,7 @@ For example, if `distance_metres` was `1`, `rot_x_deg` was `0`, and `rot_y_deg` 
 
 
 ## Cartesian Coordinates
-The Cartesian position is represented as 3 coordinates, `x`, `y` and `z`. These coordinates are relative to the view of the webcam.  
+The Cartesian position is represented as 3 coordinates, `x`, `y` and `z`. These coordinates are relative to the view of the webcam.
 
 - `x` - the x coordinate, positive in the right direction.
 - `y` - the y coordinate, positive in the up direction.


### PR DESCRIPTION
Drops references to the legacy "polar" co-ordinate space which is being deprecated, in preparation for the addition of the new "spherical" co-ordinate space.

This is done as a separate PR for merging into #67, so we can get that out sooner. I'll put up a follow-on PR which restores most of this as the "spherical" support implemented in https://github.com/sourcebots/robot-api/pull/61 and https://github.com/sourcebots/sb-vision/pull/23 shortly.