### PR TITLE
Remove edit link

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,6 @@ params:
     disableInlineCopyToClipBoard: true
     disableLanguageSwitchingButton: true
     disableAssetsBusting: true
-    editURL: "https://github.com/sourcebots/docs/tree/master/content/"
     ordersectionsby: "weight"
 
     pythonVersion: 3.5.3


### PR DESCRIPTION
This breaks broken link tests, as the files dont exist yet in master. This link is unlikely to be used anyway

Fixes tests in #94 