### PR TITLE
Clarify commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
                 command: ./scripts/build.sh
             - run:
                 name: Run Tests
-                command: npm test
+                command: npm ci-test
             - save_cache:
                 key: node-{{ checksum "package.json" }}
                 paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
                 command: ./scripts/build.sh
             - run:
                 name: Run Tests
-                command: npm ci-test
+                command: npm run ci-test
             - save_cache:
                 key: node-{{ checksum "package.json" }}
                 paths:

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "",
   "scripts": {
     "spellcheck": "mdspell --en-gb --report --ignore-acronyms --ignore-numbers --no-suggestions 'content/**/*.md'",
-    "broken-link": "blcl --recursive --ordered ./public/",
-    "test": "npm run spellcheck && npm run broken-link"
+    "broken-link-local": "blcl --recursive --ordered --exclude-external ./public/",
+    "broken-link-all": "blcl --recursive --ordered ./public/",
+    "test": "npm run spellcheck && npm run broken-link-local",
+    "ci-test": "npm run spellcheck && npm run broken-link-all"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "spellcheck": "mdspell --en-gb -ranx 'content/**/*.md'",
-    "broken-link": "blcl -ro ./public/",
+    "spellcheck": "mdspell --en-gb --report --ignore-acronyms --ignore-numbers --no-suggestions 'content/**/*.md'",
+    "broken-link": "blcl --recursive --ordered ./public/",
     "test": "npm run spellcheck && npm run broken-link"
   },
   "repository": {


### PR DESCRIPTION
This expands the command arguments to their full names so that the commands are easier to decipher and introduces a (default) version of the `test` command which doesn't require network access, thus un-breaking it for offline development.