### PR TITLE
Avoid parent issues by only using root-relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ URL: http://docs.sourcebots.co.uk
 - [Hugo](https://gohugo.io) (>=0.30)
 - [NodeJS](https://nodejs.org/) (>=6) (required for tests only)
 
+## Style notes
+
+Since our pages can almost all be accessed both with and without a trailing
+slash, we prefer all our links to be root-relative (i.e: `/foo/bar`) rather
+than parent-relative (i.e: `../bar`).
+
 ## Local Setup
 1. `npm install`
 2. `git submodule update --init`

--- a/content/kit/pi/update-file.md
+++ b/content/kit/pi/update-file.md
@@ -26,4 +26,4 @@ Do not turn off your Pi during the update process. It can take a few minutes to 
 The update process will create an `update.log` file on the USB drive. If any errors occur, they will be displayed there. If the update succeeds, the line _Upgrade complete, rebooting._ will be shown in the log.
 
 ## Failed update
-If the update fails, you can try again. If it fails multiple times, you may need to [flash your SD card](../sd-card).
+If the update fails, you can try again. If it fails multiple times, you may need to [flash your SD card](/kit/pi/sd-card).

--- a/content/tutorials/kit-assembly.md
+++ b/content/tutorials/kit-assembly.md
@@ -32,7 +32,7 @@ title: Connecting your kit
 You will need to obtain any other needed tools/supplies yourself.
 
 {{% notice info %}}
-_CamCons_ are the [green connectors](../kit-assembly.files/camcons.png) used for power wiring within our kit.
+_CamCons_ are the [green connectors](/tutorials/kit-assembly.files/camcons.png) used for power wiring within our kit.
 {{% /notice %}}
 
 ## Important notes before you start


### PR DESCRIPTION
Pages whose urls can optionally end in a trailing slash have issues with parent-relative links, so avoid them.