### PR TITLE
Add update description for kickstart image

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -26,6 +26,7 @@ enum
 H0-1
 iMAX
 IntelliSense
+kickstart
 L0-3
 LearnPython
 LiPo

--- a/content/updates/2018-kickstart.md
+++ b/content/updates/2018-kickstart.md
@@ -1,6 +1,6 @@
 ---
-title: Kickstart 2018
-date: 2018-12-16
+title: 2018 Kickstart
+date: 2017-12-16
 hidden: true
 image: https://203-97323138-gh.circle-artifacts.com/0/pi-image.img.xz
 ---

--- a/content/updates/kickstart-2018.md
+++ b/content/updates/kickstart-2018.md
@@ -1,0 +1,8 @@
+---
+title: Kickstart 2018
+date: 2018-12-16
+hidden: true
+image: https://203-97323138-gh.circle-artifacts.com/0/pi-image.img.xz
+---
+
+This is the initial version of the SourceBots kit software, which was shipped at the kickstart for the 2018 competition.

--- a/layouts/updates/list.html
+++ b/layouts/updates/list.html
@@ -16,14 +16,14 @@
       <td>{{ .Date.Format "2006-01-02" }}</td>
       <td>
         {{ if .Params.update }}
-        <a href='{{ .Params.update }}'>Download <code>update.tar.xz</code></a>
+          <a href='{{ .Params.update }}'>Download <code>update.tar.xz</code></a>
         {{ else }}
           No update file available
         {{ end }}
       </td>
       <td>
         {{ if .Params.image }}
-        <a href='{{ .Params.image }}'>Download <code>pi-image.img.xz</code></a>
+          <a href='{{ .Params.image }}'>Download <code>pi-image.img.xz</code></a>
         {{ else }}
           No SD card image available
         {{ end }}

--- a/layouts/updates/list.html
+++ b/layouts/updates/list.html
@@ -8,11 +8,10 @@
     <th>Date</th>
     <th>Update File Download</th>
     <th>Image Download</th>
-    <th>Changelog</th>
   </tr>
   {{ range .Pages.ByDate }}
     <tr>
-      <td>{{ .Title }}</td>
+      <td><a href='{{ .RelPermalink }}'>{{ .Title }}</a></td>
       <td>{{ .Date.Format "2006-01-02" }}</td>
       <td>
         {{ if .Params.update }}
@@ -28,7 +27,6 @@
           No SD card image available
         {{ end }}
       </td>
-      <td><a href='{{ .RelPermalink }}'>View Changelog</a></td>
     </tr>
   {{ end }}
 </table>

--- a/layouts/updates/list.html
+++ b/layouts/updates/list.html
@@ -11,7 +11,7 @@
   </tr>
   {{ range .Pages.ByDate }}
     <tr>
-      <td><a href='{{ .RelPermalink }}'>{{ .Title }}</a></td>
+      <td><a href='{{ .RelPermalink }}' title="See a summary of the changes in this release">{{ .Title }}</a></td>
       <td>{{ .Date.Format "2006-01-02" }}</td>
       <td>
         {{ if .Params.update }}

--- a/layouts/updates/list.html
+++ b/layouts/updates/list.html
@@ -14,8 +14,20 @@
     <tr>
       <td>{{ .Title }}</td>
       <td>{{ .Date.Format "2006-01-02" }}</td>
-      <td><a href='{{ .Params.update }}'>Download <code>update.tar.xz</code></a></td>
-      <td><a href='{{ .Params.image }}'>Download <code>pi-image.img.xz</code></a></td>
+      <td>
+        {{ if .Params.update }}
+        <a href='{{ .Params.update }}'>Download <code>update.tar.xz</code></a>
+        {{ else }}
+          No update file available
+        {{ end }}
+      </td>
+      <td>
+        {{ if .Params.image }}
+        <a href='{{ .Params.image }}'>Download <code>pi-image.img.xz</code></a>
+        {{ else }}
+          No SD card image available
+        {{ end }}
+      </td>
       <td><a href='{{ .RelPermalink }}'>View Changelog</a></td>
     </tr>
   {{ end }}

--- a/layouts/updates/single.html
+++ b/layouts/updates/single.html
@@ -4,8 +4,13 @@
 
 <table style="text-align: center">
   <tr>
-    <td><a href="{{ .Params.image }}">Download SD Card Image</a></td>
-    <td><a href="{{ .Params.update }}">Download Update File</a></td>
+    {{ if .Params.image }}
+      <td><a href="{{ .Params.image }}">Download SD Card Image</a></td>
+    {{ end }}
+
+    {{ if .Params.update }}
+      <td><a href="{{ .Params.update }}">Download Update File</a></td>
+    {{ end }}
   </tr>
 </table>
 


### PR DESCRIPTION
Add an update entry for the kickstart kit.

Also adapted the update templates, so `image` and `update` are optional frontmatter, and won't break if either doesn't exist. This is because we didn't ship an update file at kickstart, as the mechanism wasn't in-place yet.