### PR TITLE
Mention when features were added

### DIFF
--- a/content/api/servo-assembly/arduino-commands.md
+++ b/content/api/servo-assembly/arduino-commands.md
@@ -11,6 +11,8 @@ You can also extend the firmware on the Arduino to support more features, for
 example if you have other types of sensor which require higher precision timing
 than can be achieved through the Python API.
 
+{{% added_in update="2018-jan" feature="custom arduino commands" %}}
+
 ## Requirements
 
 As your new firmware will still need to be able to talk to the Python code

--- a/content/api/vision/coordinates.md
+++ b/content/api/vision/coordinates.md
@@ -41,11 +41,9 @@ approximately the same level as the camera.
    positive angle indicates that the marker is to the right of the camera's
    view.
 
-{{% notice info %}}
 For example, if `distance_metres` was `1`, `rot_x_degrees` was `0`, and
 `rot_y_degrees` was `45`, the marker would be 45 degrees to the right of the
 robot, exactly 1 metre away.
-{{% /notice %}}
 
 ## Diagram
 

--- a/content/api/vision/coordinates.md
+++ b/content/api/vision/coordinates.md
@@ -45,6 +45,8 @@ For example, if `distance_metres` was `1`, `rot_x_degrees` was `0`, and
 `rot_y_degrees` was `45`, the marker would be 45 degrees to the right of the
 robot, exactly 1 metre away.
 
+{{% added_in update="2018-jan" feature="spherical coordinates" %}}
+
 ## Diagram
 
 The following diagram shows the orientation of the Cartesian axes relative to

--- a/layouts/shortcodes/added_in.html
+++ b/layouts/shortcodes/added_in.html
@@ -15,7 +15,7 @@
   <div class="notices warning">
     <p>
       <strong>ERROR</strong>:
-      {{ errorf "Invaild update specified: '%s' does not exist." $update }}
+      {{ errorf "Invalid update specified: '%s' does not exist." $update }}
     </p>
   </div>
 {{ end }}

--- a/layouts/shortcodes/added_in.html
+++ b/layouts/shortcodes/added_in.html
@@ -1,0 +1,21 @@
+{{ $feature := .Get "feature" }}
+{{ $update := .Get "update" }}
+
+{{ with $.Site.GetPage "page" "updates" $update }}
+  <div class="notices note">
+    <p>
+      Support for <em>{{ $feature }}</em> was added in the
+      <a href="{{ .RelPermalink }}" title="{{ .LinkTitle }}">{{ .Title }}</a>
+      update. You need to be running at least that version of the kit software
+      in order to use this feature.
+    </p>
+  </div>
+{{ else }}
+  <!-- If you see this block, you've supplied an invalid update name. -->
+  <div class="notices warning">
+    <p>
+      <strong>ERROR</strong>: Invaild update specified:
+      <code>{{ $update }}</code> does not exist.
+    </p>
+  </div>
+{{ end }}

--- a/layouts/shortcodes/added_in.html
+++ b/layouts/shortcodes/added_in.html
@@ -14,8 +14,8 @@
   <!-- If you see this block, you've supplied an invalid update name. -->
   <div class="notices warning">
     <p>
-      <strong>ERROR</strong>: Invaild update specified:
-      <code>{{ $update }}</code> does not exist.
+      <strong>ERROR</strong>:
+      {{ errorf "Invaild update specified: '%s' does not exist." $update }}
     </p>
   </div>
 {{ end }}


### PR DESCRIPTION
This adds `note` boxes which explain that some of the documented features need a recent update in order to be used, along with a [shortcode](https://gohugo.io/content-management/shortcodes/) which defines the boxes.

These boxes ended up being quite a bit larger than I'd originally imagined, but I think are in-keeping with these docs (I'd originally envisioned these being a simple "New in <version>" line, like what you see in the Python docs).

Reviewers: please consider whether the boxes are suitable, both in terms of consistency and whether they're likely to be noticed.

Depends on #107.