### PR TITLE
Update hugo to 0.33

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
                 command: git submodule sync && git submodule update --init
             - run:
                 name: Install Hugo
-                command: wget https://github.com/gohugoio/hugo/releases/download/v0.31.1/hugo_0.31.1_Linux-64bit.deb -O /tmp/hugo.deb && sudo dpkg -i /tmp/hugo.deb
+                command: wget https://github.com/gohugoio/hugo/releases/download/v0.33/hugo_0.33_Linux-64bit.deb -O /tmp/hugo.deb && sudo dpkg -i /tmp/hugo.deb
             - restore_cache:
                 key: node-{{ checksum "package.json" }}
             - run:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 URL: http://docs.sourcebots.co.uk
 
 ## Requirements
-- [Hugo](https://gohugo.io) (>=0.30)
+- [Hugo](https://gohugo.io) (>=0.33)
 - [NodeJS](https://nodejs.org/) (>=6) (required for tests only)
 
 ## Style notes

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,11 @@
     command = "./scripts/build.sh"
 
 [context.production.environment]
-    HUGO_VERSION = "0.31.1"
+    HUGO_VERSION = "0.33"
     HUGO_ENV = "production"
 
 [context.deploy-preview.environment]
-    HUGO_VERSION = "0.31.1"
+    HUGO_VERSION = "0.33"
 
 [context.branch-deploy.environment]
-    HUGO_VERSION = "0.31.1"
+    HUGO_VERSION = "0.33"

--- a/shell.nix
+++ b/shell.nix
@@ -2,8 +2,8 @@
 
 with pkgs;
 
-# Require hugo >= 0.30.
-assert (builtins.compareVersions hugo.version "0.30") >= 0;
+# Require hugo >= 0.33.
+assert (builtins.compareVersions hugo.version "0.33") >= 0;
 
 stdenv.mkDerivation {
   name = "docs-env";


### PR DESCRIPTION
This adds support for a use of `.Get` which we want, though isn't actually the latest at the time of updating (only so that this upgrade is minimal).