### PR TITLE
Pre start documentation

### DIFF
--- a/content/api/_index.md
+++ b/content/api/_index.md
@@ -46,6 +46,8 @@ r = Robot(wait_for_start_button=False)
 r.power_board.wait_start()
 ```
 
+{{% added_in update="2018-02" feature="doing things before pressing the start button" %}}
+
 ## Logs
 A log file is saved on the USB drive so you can see what your robot did, what it didn't do, and any errors it raised. The file is saved to `log.txt` in the top-level directory of the USB drive.
 

--- a/content/api/_index.md
+++ b/content/api/_index.md
@@ -35,6 +35,17 @@ If this file is missing or incorrectly named, your robot won't do anything. No l
 ## Start Button
 After the robot has finished starting up, it will wait for the _Start Button_ on the power board to be pressed before continuing with your code, so that you can control when it starts moving. There is a green LED next to the start button which flashes when the robot is finished setting up and the start button can be pressed.
 
+### Doing things before pressing the start button
+If you want to do things before the start button press, such as setting servos or motors, you can pass `wait_for_start_button`. You will then need to wait for the start button [manually](power-board/#start-button).
+
+```python
+r = Robot(wait_for_start_button=False)
+
+# Do your setup here
+
+r.power_board.wait_start()
+```
+
 ## Logs
 A log file is saved on the USB drive so you can see what your robot did, what it didn't do, and any errors it raised. The file is saved to `log.txt` in the top-level directory of the USB drive.
 

--- a/content/api/power-board.md
+++ b/content/api/power-board.md
@@ -50,3 +50,12 @@ r.power_board.buzz(2, 400)
 {{% notice warning %}}
 Passing an invalid note will raise a `KeyError`. You can see all the supported notes by looking at the power boards `BUZZ_NOTES` variable by printing it (`print(r.power_board.BUZZ_NOTES)`), or [looking at the source](https://github.com/sourcebots/robot-api/blob/master/robot/power.py)
 {{% /notice %}}
+
+## Start Button
+You can manually wait for the start button to be pressed, not only at the start.
+
+```python
+r.power_board.wait_start()
+```
+
+This may be useful for debugging, but be sure to remove it in the competition, as your robot can't be interacted with!


### PR DESCRIPTION
Add documentation for doing things before the start button. This is already implemented and shipped, however was undocumented.