### PR TITLE
mention `pixel_corners` in the api

### DIFF
--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -17,8 +17,8 @@ The markers in the list have some useful attributes:
 - `is_wall_marker()` - returns whether or not the marker is a [wall marker](marker-ids/#wall-markers).
 - `is_token_marker()` - returns whether or not the marker is a [token marker](marker-ids/#token-markers).
 - `id` - returns the [id](marker-ids) of the marker.
-- `pixel_centre` - returns the [pixel](coordinates/#pixel-coordinates) co-ordinates of the centre of the marker in the captured image.
-- `pixel_corners` - returns a list of the corners of the markers in [pixel](coordinates/#pixel-coordinates) co-ordinates, clockwise with the first marker being the top left corner.
+- `pixel_centre` - returns the [pixel](coordinates/#pixel-coordinates) coordinates of the centre of the marker in the captured image.
+- `pixel_corners` - returns a list of the corners of the markers in [pixel](coordinates/#pixel-coordinates) coordinates, clockwise with the first marker being the top left corner.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.
 - `spherical` - returns details of the position of the marker in a [spherical](coordinates/#spherical-coordinates) coordinate system.
 - `polar` - *Deprecated*. Use the `spherical` attribute instead.

--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -18,7 +18,7 @@ The markers in the list have some useful attributes:
 - `is_token_marker()` - returns whether or not the marker is a [token marker](marker-ids/#token-markers).
 - `id` - returns the [id](marker-ids) of the marker.
 - `pixel_centre` - returns the [pixel](coordinates/#pixel-coordinates) coordinates of the centre of the marker in the captured image.
-- `pixel_corners` - returns a list of the corners of the markers in [pixel](coordinates/#pixel-coordinates) coordinates, clockwise with the first marker being the top left corner.
+- `pixel_corners` - returns a list of the corners of the markers in [pixel](coordinates/#pixel-coordinates) coordinates, with the first coordinate being those of the top left corner of the marker, and the being in clockwise order . This is relative to the marker's orientation, thus if the marker is upside down, the first coordinate will appear to be in the bottom right.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.
 - `spherical` - returns details of the position of the marker in a [spherical](coordinates/#spherical-coordinates) coordinate system.
 - `polar` - *Deprecated*. Use the `spherical` attribute instead.

--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -18,6 +18,7 @@ The markers in the list have some useful attributes:
 - `is_token_marker()` - returns whether or not the marker is a [token marker](marker-ids/#token-markers).
 - `id` - returns the [id](marker-ids) of the marker.
 - `pixel_centre` - returns the location in pixels of the centre of the marker in the captured image.
+- `pixel_corners` - returns a list of the corners of the markers in pixel co-ordinates, clockwise with the first marker being the top left corner.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.
 - `spherical` - returns details of the position of the marker in a [spherical](coordinates/#spherical-coordinates) coordinate system.
 - `polar` - *Deprecated*. Use the `spherical` attribute instead.

--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -17,8 +17,8 @@ The markers in the list have some useful attributes:
 - `is_wall_marker()` - returns whether or not the marker is a [wall marker](marker-ids/#wall-markers).
 - `is_token_marker()` - returns whether or not the marker is a [token marker](marker-ids/#token-markers).
 - `id` - returns the [id](marker-ids) of the marker.
-- `pixel_centre` - returns the location in pixels of the centre of the marker in the captured image.
-- `pixel_corners` - returns a list of the corners of the markers in pixel co-ordinates, clockwise with the first marker being the top left corner.
+- `pixel_centre` - returns the [pixel](coordinates/#pixel-coordinates) co-ordinates of the centre of the marker in the captured image.
+- `pixel_corners` - returns a list of the corners of the markers in [pixel](coordinates/#pixel-coordinates) co-ordinates, clockwise with the first marker being the top left corner.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.
 - `spherical` - returns details of the position of the marker in a [spherical](coordinates/#spherical-coordinates) coordinate system.
 - `polar` - *Deprecated*. Use the `spherical` attribute instead.

--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -18,7 +18,7 @@ The markers in the list have some useful attributes:
 - `is_token_marker()` - returns whether or not the marker is a [token marker](marker-ids/#token-markers).
 - `id` - returns the [id](marker-ids) of the marker.
 - `pixel_centre` - returns the [pixel](coordinates/#pixel-coordinates) coordinates of the centre of the marker in the captured image.
-- `pixel_corners` - returns a list of the corners of the markers in [pixel](coordinates/#pixel-coordinates) coordinates, with the first coordinate being those of the top left corner of the marker, and the being in clockwise order . This is relative to the marker's orientation, thus if the marker is upside down, the first coordinate will appear to be in the bottom right.
+- `pixel_corners` - returns a list of the corners of the markers in [pixel](coordinates/#pixel-coordinates) coordinates, with the first coordinate being those of the bottom left corner of the marker, and the rest being in counter-clockwise order. This is relative to the marker's orientation, thus if the marker is upside down, the first coordinate will appear to be in the top right.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.
 - `spherical` - returns details of the position of the marker in a [spherical](coordinates/#spherical-coordinates) coordinate system.
 - `polar` - *Deprecated*. Use the `spherical` attribute instead.

--- a/content/api/vision/coordinates.md
+++ b/content/api/vision/coordinates.md
@@ -54,8 +54,7 @@ the camera as well as the angles which describe the spherical coordinate space.
 
 ![A diagram showing the coordinate spaces](/img/api/coordinate-spaces.svg)
 
-
-## Pixel Coordinatesa
+## Pixel Coordinates
 
 The pixel coordinates uses 2 coordinates, `x`, and `y`. The units of the coordinates are in pixels of the [webcam](/kit/webcam/). The origin, `(0,0)` is in the top left of the camera. The `y` axis goes from top to bottom, the `x` axis goes from left to right.
 

--- a/content/api/vision/coordinates.md
+++ b/content/api/vision/coordinates.md
@@ -53,3 +53,9 @@ The following diagram shows the orientation of the Cartesian axes relative to
 the camera as well as the angles which describe the spherical coordinate space.
 
 ![A diagram showing the coordinate spaces](/img/api/coordinate-spaces.svg)
+
+
+## Pixel Coordinatesa
+
+The pixel coordinates uses 2 coordinates, `x`, and `y`. The units of the coordinates are in pixels of the [webcam](/kit/webcam/). The origin, `(0,0)` is in the top left of the camera. The `y` axis goes from top to bottom, the `x` axis goes from left to right.
+


### PR DESCRIPTION
Turns out we didn't mention pixel corner co-ordinates.

Do not merge until https://github.com/sourcebots/sb-vision/pull/45 is shipped, otherwise the "clockwise starting in the top left" will be incorrect