### PR TITLE
Removed is_wall_marker/is_token_marker

### DIFF
--- a/content/api/vision/_index.md
+++ b/content/api/vision/_index.md
@@ -14,8 +14,6 @@ markers = r.camera.see()
 ## Marker attributes
 The markers in the list have some useful attributes:
 
-- `is_wall_marker()` - returns whether or not the marker is a [wall marker](marker-ids/#wall-markers).
-- `is_token_marker()` - returns whether or not the marker is a [token marker](marker-ids/#token-markers).
 - `id` - returns the [id](marker-ids) of the marker.
 - `pixel_centre` - returns the location in pixels of the centre of the marker in the captured image.
 - `cartesian` - returns details of the position of the marker in the [Cartesian](coordinates/#cartesian-coordinates) coordinate system.

--- a/content/api/vision/marker-ids.md
+++ b/content/api/vision/marker-ids.md
@@ -71,10 +71,6 @@ marker.id in TOKEN_ZONE_0  # Does this token belong to the team in zone 0?
 Each face of the token has the same marker on. However each token has different markers.
 {{% /notice %}}
 
-{{% notice tip %}}
-It's recommended to use `marker.is_token_marker()` instead of `marker.id in TOKEN`.
-{{% /notice %}}
-
 ### All Marker Constants
 Any of the below marker constants can be imported from the `robot` module.
 


### PR DESCRIPTION
https://trello.com/c/tHwRNdfo/63-deprecate-remove-iswallmarker-istokenmarker-methods
As agreed, we are deprecating is_wall_marker and is_token_marker and encouraging the use of marker.id instead of these two methods.

Code removed in https://github.com/sourcebots/robot-api/pull/93