### PR TITLE
Separate power output control

### DIFF
--- a/content/api/power-board.md
+++ b/content/api/power-board.md
@@ -20,6 +20,17 @@ r.power_board.power_off()
 r.power_board.power_on()
 ```
 
+You can also control each output individually using the `power_on_output` and
+`power_on_output` functions. These take a single argument -- the output to
+turn on or off -- which are available as members of `PowerOutput`:
+
+```python
+from robot import PowerOutput
+
+r.power_board.power_off_output(PowerOutput.HIGH_POWER_1)
+r.power_board.power_on_output(PowerOutput.LOW_POWER_3)
+```
+
 {{% notice warning %}}
 Because the motor board is powered through these power outputs, whilst the power is off, you won't be able to control your motors. This will register as a missing board and your code will break if you try and control them.
 {{% /notice %}}

--- a/content/api/power-board.md
+++ b/content/api/power-board.md
@@ -27,8 +27,8 @@ turn on or off -- which are available as members of `PowerOutput`:
 ```python
 from robot import PowerOutput
 
-r.power_board.power_off_output(PowerOutput.HIGH_POWER_1)
-r.power_board.power_on_output(PowerOutput.LOW_POWER_3)
+r.power_board.power_off_output(PowerOutput.H1)
+r.power_board.power_on_output(PowerOutput.L3)
 ```
 
 {{% notice warning %}}

--- a/content/kit/power-board.md
+++ b/content/kit/power-board.md
@@ -13,7 +13,13 @@ the Start button which is used to start your robot code.
 ![Power Board Diagram](/img/kit/power_board_v4_diagram.png)
 
 ## Connectors
-There are six power output connectors on the board, labelled L0–L3, H0, and H1. These are enabled when your robot code is started, and supply around 11.1V (±15%). They should be used to connect to the motor board power input. The "H" connectors will supply more current than the "L" connectors.
+There are six power output connectors on the board, labelled L0–L3, H0, and H1.
+These can supply around 11.1V (±15%). The "H" connectors will supply more
+current than the "L" connectors.
+
+They should be used to connect to the motor board power input, though can also
+be used to power other devices. These are enabled when your robot code is
+started.
 
 The 5V connectors can be used to connect low-current devices that take 5V inputs, such as the Raspberry Pi and the servo shield.
 

--- a/content/kit/power-board.md
+++ b/content/kit/power-board.md
@@ -19,7 +19,7 @@ current than the "L" connectors.
 
 They should be used to connect to the motor board power input, though can also
 be used to power other devices. These are enabled when your robot code is
-started.
+started and can also be turned on or off from your code.
 
 There are two 5V connectors that can be used to connect low-current devices that take 5V inputs, such as the Raspberry Pi and the servo shield.
 

--- a/content/kit/power-board.md
+++ b/content/kit/power-board.md
@@ -21,7 +21,7 @@ They should be used to connect to the motor board power input, though can also
 be used to power other devices. These are enabled when your robot code is
 started.
 
-The 5V connectors can be used to connect low-current devices that take 5V inputs, such as the Raspberry Pi and the servo shield.
+There are two 5V connectors that can be used to connect low-current devices that take 5V inputs, such as the Raspberry Pi and the servo shield.
 
 There is also a Micro USB B connector which should be used to connect the Raspberry Pi for control of the power board.
 


### PR DESCRIPTION
Documents the separate power output control API implemented by https://github.com/sourcebots/robot-api/pull/97 as extended by https://github.com/sourcebots/robot-api/pull/101. 