### PR TITLE
Add missing trailing slash to this robots docs link

### DIFF
--- a/content/api/arduino.md
+++ b/content/api/arduino.md
@@ -27,7 +27,7 @@ The first few digital pins are occupied by digital inputs, the next few by
 digital outputs, and the analogue pins are attached to ultrasound sensors.
 
 To find out how many inputs and outputs each type of robot has, check the
-[robot docs](../../robots).
+[robot docs](../../robots/).
 
 You won't be able to change pin mode like in
 a physical robot (see below), but pins 0 and 1 are still unavailable.


### PR DESCRIPTION
Without the trailing slash, links on the robots page don't work properly. We should definitely fix that, however this works around the issue for now.