### PR TITLE
Make internal links root-relative

### DIFF
--- a/content/api/arduino.md
+++ b/content/api/arduino.md
@@ -27,7 +27,7 @@ The first few digital pins are occupied by digital inputs, the next few by
 digital outputs, and the analogue pins are attached to ultrasound sensors.
 
 To find out how many inputs and outputs each type of robot has, check the
-[robot docs](../../robots/).
+[robot docs](/robots/).
 
 You won't be able to change pin mode like in
 a physical robot (see below), but pins 0 and 1 are still unavailable.

--- a/content/api/compass.md
+++ b/content/api/compass.md
@@ -3,7 +3,7 @@ title: Compass
 weight: 10
 ---
 
-The forklift robot has a compass unit. This allows [robots](../../robots/) to determine the direction it's facing in the arena.
+The forklift robot has a compass unit. This allows [robots](/robots/) to determine the direction it's facing in the arena.
 
 ```python
 # Get the heading of the robot.

--- a/content/api/magnet.md
+++ b/content/api/magnet.md
@@ -3,8 +3,8 @@ title: Magnet API
 weight: 8
 ---
 
-The magnet is only available on the [Crane robot](../../robots/crane).
- 
+The magnet is only available on the [Crane robot](/robots/crane).
+
 The magnet of the crane will only stick to containers.
  
 ## Getting the magnet's status

--- a/content/api/servos.md
+++ b/content/api/servos.md
@@ -6,7 +6,7 @@ title: Servos
 Servos only apply to the [physical robot](/robots/physical/).
 {{% /notice %}}
 
-You can control attached servo motors from the [Arduino](../arduino/). By default, servos will be unpowered when your robot starts, and can freely rotate when turned by hand. Upon setting a value, they will hold the corresponding position. They will become unpowered again when you turn off your robot, unplug your USB stick, or set their position to the special value `None`.
+You can control attached servo motors from the [Arduino](/api/arduino/). By default, servos will be unpowered when your robot starts, and can freely rotate when turned by hand. Upon setting a value, they will hold the corresponding position. They will become unpowered again when you turn off your robot, unplug your USB stick, or set their position to the special value `None`.
 
 ## Querying servos
 

--- a/content/api/ultrasound.md
+++ b/content/api/ultrasound.md
@@ -9,13 +9,13 @@ Ultrasound sensors can measure distance of objects from the sensor. Ultrasound s
 
 Ultrasound sensors measure distance in a 18 degree diameter cone in front of the sensor, and report the closest measured distance in that cone. Ultrasound sensors also have a maximum distance. (Ultrasound sensors typically also have a minimum distance too, but we do not simulate that in our simulator).
 
-In our robots, ultrasound sensors are connected to the ['Arduino'](../arduino) board, which is used to read sensors for many different purposes. Keep reading to learn how to take measurements.
+In our robots, ultrasound sensors are connected to the ['Arduino'](/api/arduino) board, which is used to read sensors for many different purposes. Keep reading to learn how to take measurements.
 
 ## Reading the ultrasound sensor
 
 ### Simulator
 
-The ultrasound sensors will be connected to a specific pin in the Arduino, and will constantly measure distances. Consult the description of the [robot](../../robots/) to see which pin you should use. The analogue value of the pin will be the measured distance, in metres.
+The ultrasound sensors will be connected to a specific pin in the Arduino, and will constantly measure distances. Consult the description of the [robot](/robots/) to see which pin you should use. The analogue value of the pin will be the measured distance, in metres.
 
 Ultrasound sensors have a maximum range of 2 metres, if objects are further than 2m away from the robot, it will report a distance of 2m.
 

--- a/content/robots/_index.md
+++ b/content/robots/_index.md
@@ -10,4 +10,4 @@ In this year's competition we have 2 Robots, which are each controlled by their 
 
 There is also a [Physical Robot](physical).
 
-See [the API section](../api/) for more details on how to run your code.
+See [the API section](/api/) for more details on how to run your code.

--- a/content/robots/physical.md
+++ b/content/robots/physical.md
@@ -2,7 +2,7 @@
 title: Physical robot
 ---
 
-The physical robot is closely modelled after the [forklift](../forklift) robot, however is different in a few important ways. The physical robot has two [radial motors](/api/motor-board), allowing it to move itself around the arena.
+The physical robot is closely modelled after the [forklift](/robots/forklift) robot, however is different in a few important ways. The physical robot has two [radial motors](/api/motor-board), allowing it to move itself around the arena.
 
 ## Motor layout
 


### PR DESCRIPTION
This ensures that they work regardless of any trailing slash on the page that they're rendered. It also makes them more consistent and ensures they match our style (which exists to ensure they always work).

Fixes #184.

Builds on https://github.com/sourcebots/docs/pull/187 to avoid conflicts.