### PR TITLE
Replace Hugo shortcodes with mkdocs admonitions

### DIFF
--- a/docs/api/arduino.md
+++ b/docs/api/arduino.md
@@ -80,11 +80,8 @@ imported before they can be used.
 from sbot import GPIOPinMode
 ```
 
-{{% notice tip %}}
-The input modes closely resemble those of an Arduino. More information
-on them can be found in [their
-docs](https://www.arduino.cc/en/Tutorial/DigitalPins).
-{{% /notice %}}
+!!! tip
+    The input modes closely resemble those of an Arduino. More information on them can be found in [their docs](https://www.arduino.cc/en/Tutorial/DigitalPins).
 
 ### Setting the pin mode
 
@@ -138,11 +135,10 @@ have to be read differently. The Arduino has six analogue inputs, which
 are labelled `A0` to `A5`; however pins `A4` and `A5` are reserved and
 cannot be used.
 
-{{% notice tip %}}
-Analogue signals can have any voltage, while digital signals can only
-take on one of two voltages. You can read more about digital vs analogue
-signals [here](https://learn.sparkfun.com/tutorials/analog-vs-digital).
-{{% /notice %}}
+!!! tip
+    Analogue signals can have any voltage, while digital signals can only
+    take on one of two voltages. You can read more about digital vs analogue
+    signals [here](https://learn.sparkfun.com/tutorials/analog-vs-digital).
 
 ``` python
 from sbot import AnaloguePin
@@ -152,10 +148,8 @@ r.arduino.pins[AnaloguePin.A0].mode = GPIOPinMode.ANALOGUE_INPUT
 pin_value = r.arduino.pins[AnaloguePin.A0].analogue_value
 ```
 
-{{% notice tip %}}
-The values are the voltages read on the pins, between 0 and 5.
-{{% /notice %}}
+!!! tip
+    The values are the voltages read on the pins, between 0 and 5.
 
-{{% notice warning %}}
-Pins `A4` and `A5` are reserved and cannot be used.
-{{% /notice %}}
+!!! warning
+    Pins `A4` and `A5` are reserved and cannot be used.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -28,10 +28,8 @@ defined as `r`.
 Your code needs to be put in the `zone-0` or `zone-1` folder in a file called
 `forklift.py` or `crane.py` for the forklift and crane robots respectively.
 
-{{% notice tip %}}
-If this file is missing or incorrectly named, your robot won't do
-anything. No log file will be created.
-{{% /notice %}}
+!!! tip
+    If this file is missing or incorrectly named, your robot won't do anything. No log file will be created.
 
 ## Logs
 
@@ -51,7 +49,5 @@ install some extra ones which may be of use:
 - [scikit-learn 0.23.2](https://pypi.org/project/scikit-learn/0.23.2/)
 - [scipy 1.5.4](https://pypi.org/project/scipy/1.5.4/)
 
-{{% notice tip %}}
-If you would like an extra library installed, go and ask a volunteer to
-see if we can help.
-{{% /notice %}}
+!!! tip
+    If you would like an extra library installed, go and ask a volunteer to see if we can help.

--- a/docs/api/motor-board.md
+++ b/docs/api/motor-board.md
@@ -14,11 +14,8 @@ accessed using the `motor_board` property of the `Robot` object.
 my_motor_board = r.motor_board
 ```
 
-{{% notice warning %}}
-If there is more than one motor board on your kit, you *must* use the
-`motor_boards` property. `r.motor_board` *will cause an error*. This is
-because the kit doesn't know which motor board you want to access.
-{{% /notice %}}
+!!! warning
+    If there is more than one motor board on your kit, you *must* use the `motor_boards` property. `r.motor_board` *will cause an error*. This is because the kit doesn't know which motor board you want to access.
 
 Motor boards attached to your robot can be accessed under the
 `motor_boards` property of the `Robot`. The boards are indexed by their
@@ -63,17 +60,11 @@ my_motor_board.motors[1].power
 >>> -1
 ```
 
-{{% notice warning %}}
-Setting a value outside of the range `-1` to `1` will raise an exception
-and your code will crash.
-{{% /notice %}}
+!!! warning
+    Setting a value outside of the range `-1` to `1` will raise an exception and your code will crash.
 
-{{% notice warning %}}
-Sudden large changes in the motor speed setting (e.g. `-1` to `0`, `1`
-to `-1` etc.) will likely trigger the over-current protection and your
-robot will shut down with a distinct beeping noise and/or a red light
-next to the power board output that is powering the motor board.
-{{% /notice %}}
+!!! danger
+    Sudden large changes in the motor speed setting (e.g. `-1` to `0`, `1` to `-1` etc.) will likely trigger the over-current protection and your robot will shut down with a distinct beeping noise and/or a red light next to the power board output that is powering the motor board.
 
 ### Special values
 
@@ -90,9 +81,8 @@ from sbot import BRAKE, COAST
 `BRAKE` will stop the motors from turning, and thus stop your robot as
 quick as possible.
 
-{{% notice tip %}}
-`BRAKE` does the same as setting the power to `0`.
-{{% /notice %}}
+!!! note
+    `BRAKE` does the same as setting the power to `0`.
 
 ``` python
 from sbot import BRAKE

--- a/docs/api/servos.md
+++ b/docs/api/servos.md
@@ -12,9 +12,8 @@ The servo assembly can interface with up to sixteen servos connected to it.
 servo_zero = r.arduino.servos[0]
 ```
 
-{{% notice tip %}}
-Servo can be connected to any port, you don't have to start at 0!
-{{% /notice %}}
+!!! info
+    Servo can be connected to any port, you don't have to start at 0!
 
 ## Controlling servos
 
@@ -26,6 +25,5 @@ print(servo_zero.position)
 >>> 0.65
 ```
 
-{{% notice tip %}}
-When `position` is set to `None`, the servo loses power and can freely rotate. This is the same state they're in at start-up.
-{{% /notice %}}
+!!! tip
+    When `position` is set to `None`, the servo loses power and can freely rotate. This is the same state they're in at start-up.

--- a/docs/api/ultrasound.md
+++ b/docs/api/ultrasound.md
@@ -37,7 +37,5 @@ time_taken = u.pulse()
 distance_metres = u.distance()
 ```
 
-{{% notice warning %}}
-If the ultrasound signal never returns, the sensor will timeout and
-return `None`.
-{{% /notice %}}
+!!! warning
+    If the ultrasound signal never returns, the sensor will timeout and return `None`.

--- a/docs/kit/pi.md
+++ b/docs/kit/pi.md
@@ -11,6 +11,5 @@ The Raspberry Pi is enclosed in a plastic case to protect the delicate component
 ## Included software
 The software included on the Raspberry Pi allows it to run your robot. No graphical or user-required software is installed. You _do not_ need to connect to your Raspberry Pi from a computer in order to use your robot.
 
-{{% notice warning %}}
-Please do not attempt to modify the software on the Raspberry Pi. It has been configured and tested in its current configuration. Unauthorized modifications may damage your robot or prevent accurate debugging.
-{{% /notice %}}
+!!! warning
+    Please do not attempt to modify the software on the Raspberry Pi. It has been configured and tested in its current configuration. Unauthorized modifications may damage your robot or prevent accurate debugging.

--- a/docs/kit/power-board.md
+++ b/docs/kit/power-board.md
@@ -28,9 +28,8 @@ There is also a Micro USB B connector which should be used to connect the Raspbe
 
 Finally, there are connectors for external Start and On|Off switches. You may connect any latching switch for the On|Off switch, or a push-to-make button for the Start button.
 
-{{% notice note %}}
-If you intend to use only the internal On|Off switch, a CamCon must be plugged into the On|Off connector with a wire connecting one pin to the other pin on the same connector. Your power board should already have one of these plugged in.
-{{% /notice %}}
+!!! note
+    If you intend to use only the internal On|Off switch, a CamCon must be plugged into the On|Off connector with a wire connecting one pin to the other pin on the same connector. Your power board should already have one of these plugged in.
 
 ## Indicators
 |   LED      | Meaning                                                                                                           | Initial power-up state |

--- a/docs/kit/servo-assembly/GPIO.md
+++ b/docs/kit/servo-assembly/GPIO.md
@@ -6,8 +6,7 @@ The Arduino allows you to connect your kit to your own electronics. It has fourt
 
 The pin layout of the servo assembly is the same as an Arduino Uno.
 
-{{% notice note %}}
-The Arduino communicates with the servo shield using two of the analogue input pins (4 and 5), and with the Raspberry Pi using two of the digital IO pins (0 and 1). These four pins are therefore reserved, and using them may cause the Arduino or servo shield to behave unusually.
-{{% /notice %}}
+!!! note
+    The Arduino communicates with the servo shield using two of the analogue input pins (4 and 5), and with the Raspberry Pi using two of the digital IO pins (0 and 1). These four pins are therefore reserved, and using them may cause the Arduino or servo shield to behave unusually.
 
 ![Pin Map](https://raw.githubusercontent.com/Bouni/Arduino-Pinout/master/Arduino%20Uno%20R3%20Pinout.png?width=50pc)

--- a/docs/kit/servo-assembly/ultrasound.md
+++ b/docs/kit/servo-assembly/ultrasound.md
@@ -4,13 +4,11 @@ title: Ultrasound
 
 Ultrasound sensors are a useful way of measuring distance. Ultrasound sensors communicate with the kit using two wires. A signal is sent to the sensor on the _trigger_ pin, and the length of a response pulse on the _echo_ pin can be used to calculate the distance.
 
-{{% notice warning %}}
-Ultrasound should only be considered accurate up to around two metres, beyond which the signal can become distorted and produce erroneous results.
-{{% /notice %}}
+!!! warning
+    Ultrasound should only be considered accurate up to around two metres, beyond which the signal can become distorted and produce erroneous results.
 
 ## Wiring up the sensor
 The sensor has four pin connections: ground, 5V (sometimes labelled _vcc_), _trigger_ and _echo_. Most ultrasound sensors will label which pin is which. The ground and 5V should be wired to the ground and 5V pins of the Arduino respectively. The trigger and echo pins should be attached to two different digital IO pins. Take note of these two pins, you'll need them to [use the sensor](../../../api/arduino#ultrasound-sensors).
 
-{{% notice tip %}}
-If the sensor always returns a distance of zero, it means the _trigger_ and _echo_ pins are connected the wrong way! Either change the pin numbers in the code, or swap the connections.
-{{% /notice %}}
+!!! tip
+    If the sensor always returns a distance of zero, it means the _trigger_ and _echo_ pins are connected the wrong way! Either change the pin numbers in the code, or swap the connections.


### PR DESCRIPTION
As part of replacing Hugo, we should replace the warning blocks with [admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions)