### PR TITLE
Remove dark mode toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,23 +11,8 @@ theme:
     - toc.follow
     - navigation.top
   palette:
-    # Palette toggle for light mode
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: deep purple
-      accent: purple
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
-
-    # Palette toggle for dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: deep purple
-      accent: purple
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
+    primary: deep purple
+    accent: purple
 
 copyright: "&copy; SourceBots"
 


### PR DESCRIPTION
It causes images to look odd if they don't have backgrounds or have small bits of black text. As they were designed assuming a white background, let's keep to it