### PR TITLE
Add smallpeice 2023 rules

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -1,7 +1,9 @@
 ---
 title: Rules
+hide:
+    - navigation
 ---
 
-You can find the rules for Smallpeice 2021 competition here!:
+You can find the rules for Smallpeice 2023 competition here!:
 
-[Download the rules :fontawesome-solid-download:](../assets/rules.pdf){ .md-button .md-button--primary }
+[Download the rules :fontawesome-solid-download:](https://sourcebots.github.io/smallpeice-rules/){ .md-button .md-button--primary }


### PR DESCRIPTION
Blocked on https://github.com/sourcebots/smallpeice-rules/pull/24

The repository for the rules is private, and I'll make it public when we want to publish the rules. We can still merge this beforehand and let the link 404.