### PR TITLE
Change Danger to Warning in motor board API

### DIFF
--- a/docs/programming/motor-board.md
+++ b/docs/programming/motor-board.md
@@ -61,7 +61,7 @@ These values can also be read back:
 !!! warning
     Setting a value outside of the range `-1` to `1` will raise an exception and your code will crash.
 
-!!! danger
+!!! warning
     Sudden large changes in the motor speed setting (e.g. `-1` to `0`, `1` to `-1` etc.) will likely trigger the over-current protection and your robot will shut down with a distinct beeping noise and/or a red light next to the power board output that is powering the motor board.
 
 ### Special values


### PR DESCRIPTION
Triggering over-current protection isn't actually dangerous. So we should adjust this to a warning.